### PR TITLE
updates to match new upstream content

### DIFF
--- a/baseline.sh
+++ b/baseline.sh
@@ -18,5 +18,5 @@ gem install r10k
 
 pushd /etc/puppet
 PUPPETFILE=/root/centos-cloud/puppet/Puppetfile r10k puppetfile install -v
-mv /root/centos-cloud/puppet/modules/centos_cloud modules/
+cp -a /root/centos-cloud/puppet/modules/centos_cloud modules/
 popd

--- a/puppet/modules/centos_cloud/manifests/compute/nova.pp
+++ b/puppet/modules/centos_cloud/manifests/compute/nova.pp
@@ -45,11 +45,6 @@ class centos_cloud::compute::nova (
     neutron_password   => $neutron_password,
   }
 
-  # https://bugs.launchpad.net/puppet-nova/+bug/1567157
-  nova_config { 'DEFAULT/use_neutron':
-    value => true;
-  }
-
   include ::nova::vncproxy
   include ::nova::consoleauth
 }

--- a/puppet/modules/centos_cloud/manifests/controller/neutron.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/neutron.pp
@@ -87,10 +87,10 @@ class centos_cloud::controller::neutron (
 
   # Provider subnet
   neutron_subnet { 'publicsubnet':
-    cidr             => '172.22.6.0/23',
-    gateway_ip       => '172.22.7.254',
+    cidr             => '172.19.4.0/22',
+    gateway_ip       => '172.19.7.254',
     network_name     => 'publicnet',
-    dns_nameservers  => ['172.22.7.245'],
-    allocation_pools => ["start=172.22.6.50,end=172.22.7.240"],
+    dns_nameservers  => ['172.19.7.253'],
+    allocation_pools => ["start=172.19.4.10,end=172.19.7.250"],
   }
 }

--- a/puppet/modules/centos_cloud/manifests/controller/nova.pp
+++ b/puppet/modules/centos_cloud/manifests/controller/nova.pp
@@ -85,11 +85,6 @@ class centos_cloud::controller::nova (
     neutron_password   => $neutron_password,
   }
 
-  # https://bugs.launchpad.net/puppet-nova/+bug/1567157
-  nova_config { 'DEFAULT/use_neutron':
-    value => true;
-  }
-
   include ::nova::client
   include ::nova::conductor
   include ::nova::cron::archive_deleted_rows

--- a/puppet/modules/centos_cloud/manifests/server/auth_file.pp
+++ b/puppet/modules/centos_cloud/manifests/server/auth_file.pp
@@ -1,6 +1,6 @@
 class centos_cloud::server::auth_file (
   $controller = "controller.openstack.ci.centos.org",
-  $password = "keystone"
+  $password = "keystone",
   $path = '/root/openrc'
 ){
   class { '::openstack_extras::auth_file':

--- a/puppet/modules/centos_cloud/manifests/server/auth_file.pp
+++ b/puppet/modules/centos_cloud/manifests/server/auth_file.pp
@@ -13,6 +13,6 @@ class centos_cloud::server::auth_file (
 
   exec { 'Setup openstackclient bash completion':
     command => "/usr/bin/openstack complete >> ${path}",
-    unless  => "grep -q '_openstack()' ${path}"
+    unless  => "/usr/bin/grep -q '_openstack()' ${path}"
   }
 }


### PR DESCRIPTION
had to make a few changes, and use cp instead of mv, that means we can still do re-runs on the hosts.